### PR TITLE
OCP pre-release nerfs

### DIFF
--- a/db/re/item_combo_db.txt
+++ b/db/re/item_combo_db.txt
@@ -63,12 +63,12 @@
 1618:2509:19139,{ .@r = getequiprefinerycnt(EQI_HAND_R); bonus bMatkRate,1; if (.@r >= 5) { bonus bMatkRate,2; if (.@r >= 7) { bonus bMatkRate,2; } } }
 1618:2535,{ bonus bMatkRate,5; bonus2 bSubEle,Ele_Neutral,25; }
 1618:19020,{ .@r = getequiprefinerycnt(EQI_HAND_R); bonus bMatk,.@r*10; if (.@r >= 10) { autobonus "{ bonus bVariableCastrate,-50; }",100,5000,BF_MAGIC; /* Confirm: Success rate? */ } }
-1618:19139,{ .@r = getequiprefinerycnt(EQI_HAND_R); bonus bMatk,10*.@r; if (.@r>=10) { bonus bVariableCastrate,-3; bonus2 bSkillAtk,"WL_EARTHSTRAIN",15; bonus2 bSkillAtk,"WL_CHAINLIGHTNING",15; bonus2 bSkillAtk,"WZ_HEAVENDRIVE",70; bonus2 bSkillAtk,"WZ_JUPITEL",70; } if (BaseLevel>=100) { bonus bVariableCastrate,-3; bonus2 bSkillAtk,"WL_EARTHSTRAIN",30; bonus2 bSkillAtk,"WL_CHAINLIGHTNING",30; bonus2 bSkillAtk,"WZ_HEAVENDRIVE",140; bonus2 bSkillAtk,"WZ_JUPITEL",140; } }
+1618:19139,{ .@r = getequiprefinerycnt(EQI_HAND_R); bonus bMatk,10*.@r; if (.@r>=10) { bonus bVariableCastrate,-3; bonus2 bSkillAtk,"WL_EARTHSTRAIN",15; bonus2 bSkillAtk,"WL_CHAINLIGHTNING",15; } if (BaseLevel>=100) { bonus bVariableCastrate,-3; bonus2 bSkillAtk,"WL_EARTHSTRAIN",30; bonus2 bSkillAtk,"WL_CHAINLIGHTNING",30; bonus2 bSkillAtk,"WZ_HEAVENDRIVE",210; bonus2 bSkillAtk,"WZ_JUPITEL",210; } }
 1618:20813,{ bonus bMaxHP,300; bonus bMatkRate,getequiprefinerycnt(EQI_HAND_R)-5; bonus2 bSubEle,Ele_Neutral,getequiprefinerycnt(EQI_GARMENT)*3; }
 1618:20813:19139,{ .@r = getequiprefinerycnt(EQI_HAND_R); bonus bMatkRate,1; if (.@r >= 5) { bonus bMatkRate,2; if (.@r >= 7) { bonus bMatkRate,2; } } }
 1618:20847,{ .@weapon = getequiprefinerycnt(EQI_HAND_R); .@eq = getequiprefinerycnt(EQI_GARMENT); .@weapon = min(.@weapon,10); bonus bMaxHP,1000; bonus bMatk,(-50+(20*.@weapon)); bonus bDelayrate,-(3*(.@weapon/3)); bonus2 bSubEle,Ele_Neutral,(min(.@eq,10)/2); }
 1619:19020,{ .@r = getequiprefinerycnt(EQI_HAND_R); bonus bMatk,.@r*10; if (.@r >= 10) { autobonus "{ bonus bVariableCastrate,-50; }",100,5000,BF_MAGIC; /* Confirm: Success rate? */ } }
-1620:19139,{ .@r = getequiprefinerycnt(EQI_HAND_R); bonus bMatk,10*.@r; if (.@r>=10) { bonus bVariableCastrate,-3; bonus2 bSkillAtk,"WL_EARTHSTRAIN",15; bonus2 bSkillAtk,"WL_CHAINLIGHTNING",15; bonus2 bSkillAtk,"WZ_HEAVENDRIVE",70; bonus2 bSkillAtk,"WZ_JUPITEL",70; } if (BaseLevel>=100) { bonus bVariableCastrate,-3; bonus2 bSkillAtk,"WL_EARTHSTRAIN",30; bonus2 bSkillAtk,"WL_CHAINLIGHTNING",30; bonus2 bSkillAtk,"WZ_HEAVENDRIVE",140; bonus2 bSkillAtk,"WZ_JUPITEL",140; } }
+1620:19139,{ .@r = getequiprefinerycnt(EQI_HAND_R); bonus bMatk,10*.@r; if (.@r>=10) { bonus bVariableCastrate,-3; bonus2 bSkillAtk,"WL_EARTHSTRAIN",15; bonus2 bSkillAtk,"WL_CHAINLIGHTNING",15; } if (BaseLevel>=100) { bonus bVariableCastrate,-3; bonus2 bSkillAtk,"WL_EARTHSTRAIN",30; bonus2 bSkillAtk,"WL_CHAINLIGHTNING",30; bonus2 bSkillAtk,"WZ_HEAVENDRIVE",210; bonus2 bSkillAtk,"WZ_JUPITEL",210; } }
 1620:20813,{ bonus bMaxHP,300; bonus bMatkRate,getequiprefinerycnt(EQI_HAND_R)-5; bonus2 bSubEle,Ele_Neutral,getequiprefinerycnt(EQI_GARMENT)*3; }
 1620:20813:19139,{ .@r = getequiprefinerycnt(EQI_HAND_R); bonus bMatkRate,1; if (.@r >= 5) { bonus bMatkRate,2; if (.@r >= 7) { bonus bMatkRate,2; } } }
 1620:2509,{ bonus bMaxHP,300; bonus bMatkRate,getequiprefinerycnt(EQI_HAND_R)-5; if(getequiprefinerycnt(EQI_GARMENT) > 10) { bonus2 bSubEle,Ele_Neutral,30; } else { bonus2 bSubEle,Ele_Neutral,getequiprefinerycnt(EQI_GARMENT)*3; } }
@@ -1175,10 +1175,10 @@
 20925:22035,{ bonus bAgi,10; bonus bInt,10; bonus bVariableCastrate,-10; bonus2 bSubRace,RC_Player_Human,5; }
 20925:22036,{ bonus bStr,10; bonus bDex,10; bonus bDelayrate,-20; bonus2 bSubRace,RC_Player_Human,5; }
 20925:22037,{ bonus bVit,10; bonus bLuk,10; bonus bHealPower,20; bonus2 bSubRace,RC_Player_Human,5; bonus bUseSPrate,-10; }
-20931:1752,{ bonus2 bSubEle,Ele_Fire,75; }
-20931:1754,{ bonus2 bSubEle,Ele_Water,75; }
-20931:1755,{ bonus2 bSubEle,Ele_Wind,75; }
-20931:1756,{ bonus2 bSubEle,Ele_Earth,75; }
+20931:1752,{ bonus2 bSubEle,Ele_Fire,50; } // original 75
+20931:1754,{ bonus2 bSubEle,Ele_Water,50; } // original 75
+20931:1755,{ bonus2 bSubEle,Ele_Wind,50; } // original 75
+20931:1756,{ bonus2 bSubEle,Ele_Earth,50; } // original 75
 20933:22196,{ bonus bCritAtkRate,10; }
 20933:22197,{ bonus bVariableCastrate,-10; }
 20934:22196,{ bonus bLongAtkRate,10; }
@@ -1524,10 +1524,10 @@
 28499:28920,{ bonus bFlee2,10; }
 28501:4807,{ bonus bAspd,1; bonus2 bSubRace,RC_DemiHuman,1; bonus2 bSubRace,RC_Brute,1; bonus2 bSubRace,RC_Player_Doram,1; bonus2 bSubRace,RC_Fish,1; bonus2 bSubRace,RC_Player_Human,1; bonus2 bSubRace,RC_Demon,1; bonus2 bSubRace,RC_Undead,1; }
 28501:4842,{ bonus bAspd,1; bonus2 bSubRace,RC_DemiHuman,1; bonus2 bSubRace,RC_Brute,1; bonus2 bSubRace,RC_Player_Doram,1; bonus2 bSubRace,RC_Fish,1; bonus2 bSubRace,RC_Player_Human,1; bonus2 bSubRace,RC_Demon,1; bonus2 bSubRace,RC_Undead,1; }
-28502:2201,{ .@a = (readparam(bStr)+readparam(bLuk))/80; .@b = (readparam(bAgi)+readparam(bVit))/80; .@c = (readparam(bInt)+readparam(bDex))/80; bonus bMaxHPrate,5*.@b; bonus2 bAddClass,Class_All,6*.@a; bonus bMatk,120*.@c; bonus bCritical,5*.@a; bonus bAspdRate,5*.@b; bonus bVariableCastrate,-3*.@c; bonus bCritAtkRate,10*.@a; bonus2 bSubRace,RC_DemiHuman,((2*.@b)+2); bonus2 bSubRace,RC_Player_Human,((2*.@b)+2); bonus bHealPower,10*.@c; }
-28502:2202,{ .@a = (readparam(bStr)+readparam(bLuk))/80; .@b = (readparam(bAgi)+readparam(bVit))/80; .@c = (readparam(bInt)+readparam(bDex))/80; bonus bMaxHPrate,5*.@b; bonus2 bAddClass,Class_All,6*.@a; bonus bMatk,120*.@c; bonus bCritical,5*.@a; bonus bAspdRate,5*.@b; bonus bVariableCastrate,-3*.@c; bonus bCritAtkRate,10*.@a; bonus2 bSubRace,RC_DemiHuman,((2*.@b)+2); bonus2 bSubRace,RC_Player_Human,((2*.@b)+2); bonus bHealPower,10*.@c; }
-28502:2203,{ .@a = (readparam(bStr)+readparam(bLuk))/80; .@b = (readparam(bAgi)+readparam(bVit))/80; .@c = (readparam(bInt)+readparam(bDex))/80; bonus bMaxHPrate,5*.@b; bonus2 bAddClass,Class_All,6*.@a; bonus bMatk,120*.@c; bonus bCritical,5*.@a; bonus bAspdRate,5*.@b; bonus bVariableCastrate,-3*.@c; bonus bCritAtkRate,10*.@a; bonus2 bSubRace,RC_DemiHuman,((2*.@b)+2); bonus2 bSubRace,RC_Player_Human,((2*.@b)+2); bonus bHealPower,10*.@c; }
-28502:2204,{ .@a = (readparam(bStr)+readparam(bLuk))/80; .@b = (readparam(bAgi)+readparam(bVit))/80; .@c = (readparam(bInt)+readparam(bDex))/80; bonus bMaxHPrate,5*.@b; bonus2 bAddClass,Class_All,6*.@a; bonus bMatk,120*.@c; bonus bCritical,5*.@a; bonus bAspdRate,5*.@b; bonus bVariableCastrate,-3*.@c; bonus bCritAtkRate,10*.@a; bonus2 bSubRace,RC_DemiHuman,((2*.@b)+2); bonus2 bSubRace,RC_Player_Human,((2*.@b)+2); bonus bHealPower,10*.@c; }
+28502:2201,{ .@a = (readparam(bStr)+readparam(bLuk))/80; .@b = (readparam(bAgi)+readparam(bVit))/80; .@c = (readparam(bInt)+readparam(bDex))/80; bonus bMaxHPrate,3*.@b; bonus2 bAddClass,Class_All,3*.@a; bonus bMatk,60*.@c; bonus bCritical,3*.@a; bonus bAspdRate,3*.@b; bonus bVariableCastrate,-3*.@c; bonus bCritAtkRate,5*.@a; bonus2 bSubRace,RC_DemiHuman,((2*.@b)+2); bonus2 bSubRace,RC_Player_Human,((2*.@b)+2); bonus bHealPower,5*.@c; }
+28502:2202,{ .@a = (readparam(bStr)+readparam(bLuk))/80; .@b = (readparam(bAgi)+readparam(bVit))/80; .@c = (readparam(bInt)+readparam(bDex))/80; bonus bMaxHPrate,3*.@b; bonus2 bAddClass,Class_All,3*.@a; bonus bMatk,60*.@c; bonus bCritical,3*.@a; bonus bAspdRate,3*.@b; bonus bVariableCastrate,-3*.@c; bonus bCritAtkRate,5*.@a; bonus2 bSubRace,RC_DemiHuman,((2*.@b)+2); bonus2 bSubRace,RC_Player_Human,((2*.@b)+2); bonus bHealPower,5*.@c; }
+28502:2203,{ .@a = (readparam(bStr)+readparam(bLuk))/80; .@b = (readparam(bAgi)+readparam(bVit))/80; .@c = (readparam(bInt)+readparam(bDex))/80; bonus bMaxHPrate,3*.@b; bonus2 bAddClass,Class_All,3*.@a; bonus bMatk,60*.@c; bonus bCritical,3*.@a; bonus bAspdRate,3*.@b; bonus bVariableCastrate,-3*.@c; bonus bCritAtkRate,5*.@a; bonus2 bSubRace,RC_DemiHuman,((2*.@b)+2); bonus2 bSubRace,RC_Player_Human,((2*.@b)+2); bonus bHealPower,5*.@c; }
+28502:2204,{ .@a = (readparam(bStr)+readparam(bLuk))/80; .@b = (readparam(bAgi)+readparam(bVit))/80; .@c = (readparam(bInt)+readparam(bDex))/80; bonus bMaxHPrate,3*.@b; bonus2 bAddClass,Class_All,3*.@a; bonus bMatk,60*.@c; bonus bCritical,3*.@a; bonus bAspdRate,3*.@b; bonus bVariableCastrate,-3*.@c; bonus bCritAtkRate,5*.@a; bonus2 bSubRace,RC_DemiHuman,((2*.@b)+2); bonus2 bSubRace,RC_Player_Human,((2*.@b)+2); bonus bHealPower,5*.@c; }
 28506:1414,{ .@r = getequiprefinerycnt(EQI_HAND_R); if (.@r>=7) { .@val = 30; if (.@r>=9) { .@val += 20; bonus2 bAddClass,Class_Boss,.@val; bonus2 bAddEle,Ele_Water,.@val; bonus2 bAddEle,Ele_Wind,.@val; bonus2 bAddRace,RC_Fish,.@val; bonus2 bAddRace,RC_Insect,.@val; bonus2 bSkillAtk,"RK_WINDCUTTER",.@val; if (.@r>=10) { bonus2 bVariableCastrate,"RK_WINDCUTTER",-50; } } } }
 28506:1449,{ .@r = getequiprefinerycnt(EQI_HAND_R); if (.@r>=7) { .@val = 30; if (.@r>=9) { .@val += 20; bonus2 bAddClass,Class_Boss,.@val; bonus2 bAddEle,Ele_Water,.@val; bonus2 bAddEle,Ele_Wind,.@val; bonus2 bAddRace,RC_Fish,.@val; bonus2 bAddRace,RC_Insect,.@val; bonus2 bSkillAtk,"RK_WINDCUTTER",.@val; if (.@r>=10) { bonus2 bVariableCastrate,"RK_WINDCUTTER",-50; } } } }
 28506:15037,{ .@r = getequiprefinerycnt(EQI_ARMOR); bonus2 bResEff,Eff_Freeze,10000; bonus2 bSubRace,RC_DemiHuman,3; bonus2 bSubRace,RC_Player_Human,3; if (.@r>=7) { bonus bMaxHPrate,15; bonus2 bSubRace,RC_DemiHuman,2; bonus2 bSubRace,RC_Player_Human,2; } if (.@r>=9) { bonus bMaxHPrate,15; bonus2 bSubRace,RC_DemiHuman,2; bonus2 bSubRace,RC_Player_Human,2; } }
@@ -1537,12 +1537,12 @@
 28506:2884,{ bonus2 bAddClass,Class_All,5; bonus bMaxSPrate,5; bonus bAspdRate,5; bonus2 bSubRace,RC_DemiHuman,4; bonus2 bSubRace,RC_Player_Human,4; }
 28508:28612,{ .@r = getequiprefinerycnt(EQI_HAND_R); bonus bAspdRate,8; bonus bCritAtkRate,(5*(.@r/2)); if (.@r >= 9) { bonus bCritical,15; bonus2 bResEff,Eff_Curse,10000; if (.@r >= 11) { bonus bBaseAtk,100; } } }
 28509:28626,{ .@r = getequiprefinerycnt(EQI_HAND_R); bonus bAspdRate,8; bonus bCritAtkRate,(5*(.@r/2)); if (.@r >= 9) { bonus bCritical,15; if (.@r >= 11) { bonus bBaseAtk,100; } } }
-28594:4875,{ bonus bStr,40; bonus bMaxHPrate,10; }
-28594:4876,{ bonus bInt,40; bonus bMaxSPrate,10; }
+28594:4875,{ bonus bStr,30; bonus bMaxHPrate,10; }
+28594:4876,{ bonus bInt,30; bonus bMaxSPrate,10; }
 28594:4877,{ bonus bDelayrate,-30; bonus bFlee,40; }
 28594:4878,{ bonus bMdef,40; bonus bVariableCastrate,-20; }
-28594:4879,{ bonus bDex,40; bonus bHit,50; }
-28594:4880,{ bonus bLuk,40; bonus bCritAtkRate,30; }
+28594:4879,{ bonus bDex,5; bonus bHit,50; bonus bLongAtkRate,15; }
+28594:4880,{ bonus bLuk,30; bonus bCritAtkRate,30; }
 28763:28764,{ .@r = getequiprefinerycnt(EQI_HAND_R) + getequiprefinerycnt(EQI_HAND_L); bonus bBaseAtk,10*(.@r/3); bonus2 bAddClass,Class_All,2*(.@r/5); if (.@r >= 14) { .@val = 25; if (.@r >= 16) { bonus2 bSkillCooldown,"KO_JYUMONJIKIRI",-2000; if (.@r >= 18) { .@lvl = max(getskilllv("KG_KAGEHUMI"),getskilllv("OB_ZANGETSU")); skill "KG_KAGEHUMI",.@lvl; skill "OB_ZANGETSU",.@lvl; if (.@r >= 20) { .@val += 25; } } } bonus2 bSkillAtk,"KO_JYUMONJIKIRI",.@val; } }
 28765:28766,{ .@a = getequiprefinerycnt(EQI_HAND_L); .@b = getequiprefinerycnt(EQI_HAND_R); if (.@a+.@b >= 16) { bonus2 bSkillAtk,"GC_CROSSIMPACT",20; bonus2 bSkillAtk,"GC_COUNTERSLASH",20; } if (.@a+.@b >= 18) bonus2 bAddClass,Class_All,12; if (.@a+.@b >= 20) .@val = 20; bonus2 bSkillAtk,"ASC_BREAKER",40+.@val; bonus2 bSkillAtk,"ASC_METEORASSAULT",40+.@val; bonus bBaseAtk,8*((.@a+.@b)/2); }
 28906:2998,{ bonus bLongAtkRate,10; }

--- a/db/re/item_db_equip.yml
+++ b/db/re/item_db_equip.yml
@@ -99681,7 +99681,7 @@ Body:
       Both_Accessory: true
     EquipLevelMin: 80
     Script: |
-      bonus bDelayrate,-10; bonus2 bAddClass,Class_Boss,5; bonus2 bIgnoreDefRaceRate,RC_All,50;
+      bonus bDelayrate,-10; bonus2 bAddClass,Class_Boss,5; bonus2 bIgnoreDefRaceRate,RC_All,20; bonus2 bonus2 bIgnoreDefRaceRate,RC_Player_human,-20;
   - Id: 28533
     AegisName: Chemical_Glove
     Name: Chemical Glove
@@ -99804,7 +99804,7 @@ Body:
       Left_Accessory: true
     EquipLevelMin: 80
     Script: |
-      .@s = readparam(bStr); .@a = readparam(bAgi); .@d = readparam(bDex); .@v = readparam(bvit); .@l = readparam(bLuk); .@i = readparam(bInt); bonus bStr,3*(.@i/18); bonus bAgi,3*(.@l/18); bonus bVit,3*(.@d/18); bonus bInt,3*(.@s/18); bonus bDex,3*(.@v/18); bonus bLuk,3*(.@a/18); bonus bMaxHPrate,(.@d/18); bonus bFlee2,(.@a/18); bonus bMaxHPrate,(.@d/18); bonus bVariableCastrate,-(.@v/18); bonus bDelayrate,-(.@i/18); bonus2 bIgnoreDefClassRate,Class_All,15*(.@l/18); bonus2 bIgnoreMdefClassRate,Class_All,15*(.@s/18);
+      .@s = readparam(bStr); .@a = readparam(bAgi); .@d = readparam(bDex); .@v = readparam(bvit); .@l = readparam(bLuk); .@i = readparam(bInt); bonus bStr,3*(.@i/18); bonus bAgi,3*(.@l/18); bonus bVit,3*(.@d/18); bonus bInt,3*(.@s/18); bonus bDex,3*(.@v/18); bonus bLuk,3*(.@a/18); bonus bMaxHPrate,(.@d/18); bonus bFlee2,(.@a/18); bonus bMaxHPrate,(.@d/18); bonus bVariableCastrate,-(.@v/18); bonus bDelayrate,-(.@i/18); if (BaseLevel>=100) { bonus2 bIgnoreMdefClassRate,Class_All,8*(.@s/18); bonus2 bIgnoreMdefRaceRate,RC_Player_Human,-8*(.@s/18); } if (BaseLevel>=100) { bonus2 bIgnoreDefClassRate,Class_All,5*(.@i/18); bonus2 bIgnoreDefClassRate,RC_Player_Human,-5*(.@i/18); };
   - Id: 28566
     AegisName: Beginner's_Ring
     Name: Beginner's Ring

--- a/db/re/item_db_equip.yml
+++ b/db/re/item_db_equip.yml
@@ -99532,7 +99532,7 @@ Body:
       Both_Accessory: true
     EquipLevelMin: 80
     Script: |
-      bonus bVariableCastrate,-10; bonus2 bMagicAtkEle,Ele_Earth,5; bonus2 bMagicAtkEle,Ele_Water,5; bonus2 bMagicAtkEle,Ele_Wind,5; bonus2 bMagicAtkEle,Ele_Fire,5; bonus2 bMagicAtkEle,Ele_Ghost,5; bonus2 bIgnoreMdefRaceRate,RC_All,50;
+      bonus bVariableCastrate,-10; bonus2 bMagicAtkEle,Ele_Earth,5; bonus2 bMagicAtkEle,Ele_Water,5; bonus2 bMagicAtkEle,Ele_Wind,5; bonus2 bMagicAtkEle,Ele_Fire,5; bonus2 bMagicAtkEle,Ele_Ghost,5; bonus2 bIgnoreMdefRaceRate,RC_All,25;
   - Id: 28508
     AegisName: Illusion_Skull_Ring
     Name: Illusion Skull Ring

--- a/db/re/item_db_equip.yml
+++ b/db/re/item_db_equip.yml
@@ -99681,7 +99681,7 @@ Body:
       Both_Accessory: true
     EquipLevelMin: 80
     Script: |
-      bonus bDelayrate,-10; bonus2 bAddClass,Class_Boss,5; bonus2 bIgnoreDefRaceRate,RC_All,20; bonus2 bonus2 bIgnoreDefRaceRate,RC_Player_human,-20;
+      bonus bDelayrate,-10; bonus2 bAddClass,Class_Boss,5; bonus2 bIgnoreDefRaceRate,RC_All,20; bonus2 bIgnoreDefRaceRate,RC_Player_human,-20;
   - Id: 28533
     AegisName: Chemical_Glove
     Name: Chemical Glove


### PR DESCRIPTION
Changes to:
28565	Perverse Demon Mask [1]
28531	Blacksmith's Gloves [1]
19139	Survivor's Orb
20931	Prism Ranger Scarf
28502	Mob Scarf
28594	Temporal Ring [1]

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the ChocobotRO [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/Latiosu/chocobotro/issues/new) first and then link your pull request to the amendment!
-->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
