### PR TITLE
Lower duel cooldown

### DIFF
--- a/conf/battle/misc.conf
+++ b/conf/battle/misc.conf
@@ -86,8 +86,8 @@ duel_allow_teleport: no
 // Autoleave duel when die
 duel_autoleave_when_die: yes
 
-// Delay between using @duel in minutes
-duel_time_interval: 1
+// Delay between using @duel in seconds
+duel_time_interval: 60
 
 // Restrict duel usage to same map
 duel_only_on_same_map: no

--- a/conf/import/battle_conf.txt
+++ b/conf/import/battle_conf.txt
@@ -1,0 +1,1 @@
+duel_time_interval: 10

--- a/conf/msg_conf/map_msg.conf
+++ b/conf/msg_conf/map_msg.conf
@@ -377,7 +377,7 @@
 353: Duel: The Player is in the duel already.
 354: Duel: Invitation has been sent.
 355: Duel: You can't use @duel without @reject.
-356: Duel: You can take part in duel once per %d minutes.
+356: Duel: You can take part in duel once per %d seconds.
 357: Duel: Invalid value.
 358: Duel: You can't use @leave. You aren't a duelist.
 359: Duel: You've left the duel.

--- a/src/map/duel.cpp
+++ b/src/map/duel.cpp
@@ -55,7 +55,7 @@ void duel_savetime(struct map_session_data* sd)
 	time(&timer);
 	t = localtime(&timer);
 
-	pc_setglobalreg(sd, add_str("PC_LAST_DUEL_TIME"), t->tm_mday*24*60 + t->tm_hour*60 + t->tm_min);
+	pc_setglobalreg(sd, add_str("PC_LAST_DUEL_TIME"), t->tm_mday*24*10 + t->tm_hour*10 + t->tm_min);
 }
 
 /*
@@ -70,7 +70,7 @@ bool duel_checktime(struct map_session_data* sd)
 	time(&timer);
 	t = localtime(&timer);
 
-	diff = t->tm_mday*24*60 + t->tm_hour*60 + t->tm_min - pc_readglobalreg(sd, add_str("PC_LAST_DUEL_TIME"));
+	diff = t->tm_mday*24*10 + t->tm_hour*10 + t->tm_min - pc_readglobalreg(sd, add_str("PC_LAST_DUEL_TIME"));
 
 	return !(diff >= 0 && diff < battle_config.duel_time_interval);
 }

--- a/src/map/duel.cpp
+++ b/src/map/duel.cpp
@@ -45,7 +45,7 @@ size_t duel_countactives()
 static void duel_set(const size_t did, struct map_session_data* sd);
 
 /*
- * Save the current time of the duel in PC_LAST_DUEL_TIME
+ * Save the current time of the duel in PC_LAST_DUEL_TIME (in seconds)
  */
 void duel_savetime(struct map_session_data* sd)
 {
@@ -55,11 +55,11 @@ void duel_savetime(struct map_session_data* sd)
 	time(&timer);
 	t = localtime(&timer);
 
-	pc_setglobalreg(sd, add_str("PC_LAST_DUEL_TIME"), t->tm_mday*24*10 + t->tm_hour*10 + t->tm_min);
+	pc_setglobalreg(sd, add_str("PC_LAST_DUEL_TIME"), t->tm_mday*24*60*60 + t->tm_hour*60*60 + t->tm_min*60 + t->tm_sec);
 }
 
 /*
- * Check if the time elapsed between last duel is enough to launch another.
+ * Check if the time elapsed (in seconds) between last duel is enough to launch another.
  */
 bool duel_checktime(struct map_session_data* sd)
 {
@@ -70,7 +70,7 @@ bool duel_checktime(struct map_session_data* sd)
 	time(&timer);
 	t = localtime(&timer);
 
-	diff = t->tm_mday*24*10 + t->tm_hour*10 + t->tm_min - pc_readglobalreg(sd, add_str("PC_LAST_DUEL_TIME"));
+	diff = t->tm_mday*24*60*60 + t->tm_hour*60*60 + t->tm_min*60 + t->tm_sec - pc_readglobalreg(sd, add_str("PC_LAST_DUEL_TIME"));
 
 	return !(diff >= 0 && diff < battle_config.duel_time_interval);
 }


### PR DESCRIPTION
Completely redundant cooldown timer of 60 seconds is very frustrating. Lowered to 10 seconds so that players can continue to duel as desired.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the ChocobotRO [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/Latiosu/chocobotro/issues/new) first and then link your pull request to the amendment!
-->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
